### PR TITLE
Integration of subroutines g(r) and mean square displacement: WARNING a unexpected error occurs when calling g(r)

### DIFF
--- a/MEANSQUAREDISP_SUBROUTINE.f90
+++ b/MEANSQUAREDISP_SUBROUTINE.f90
@@ -3,8 +3,10 @@
 !Rfixed(in): fixed configuration of the particles from which the meansquaredisp is computed
 !L(in): system length
 !meansquaredisp(out): Value of the meansquaredisp of this time step
-subroutine MSDISPLACEMENT(Rcurrent,Rfixed,L,meansquaredisp)
-real,intent(in):: Rcurrent(:,:),Rfixed(:,:)
+subroutine MSDISPLACEMENT(npar,dim,Rcurrent,Rfixed,L,meansquaredisp)
+implicit none
+integer,intent(in) :: npar,dim
+real,intent(in):: Rcurrent(npar,dim),Rfixed(npar,dim)
 real,intent(in):: L
 real,intent(out):: meansquaredisp
 real:: R(3)

--- a/input.dat
+++ b/input.dat
@@ -1,3 +1,4 @@
+1000	!!equilibration timesteps
 10000  !timesteps
 3      !!dimension
 108    !!particles
@@ -5,9 +6,11 @@
 0.998d3       !! energy unit (eps) Argon : J/mol
 39.95d0	   !! mass g/mol
 1d-3   !!simulation dt
-40d0   !! Berensden parameter temperature
+50d0   !! Berensden parameter temperature
 50d0   !! Berensden parameter pressure
 1.4d0  !!density g/cm^3
 1.5d0  !!cutoff radius, in reduced units (particle radius=1)
 270d0     !!temperature, in Kelvin
 2d0      !! pressure, in ATM
+1,1000     !!number of time steps to measure g(r) and mean square displacement
+500	 !!Number of positions to calculate radial distribution function


### PR DESCRIPTION
The program works perfectly except for one smally balloney littlely thing: It explodes when you call the radial distribution function calculation. So don't call it if you don't want your program to explode. 

The bug however is localised, and we have evidence to think that it is produced on on the line 30 (approximately) of the program GR_SUBROUTINE.f90, specifically, when interv=(xmax-xmin)/dble(ncajas), and more specifically, when definining interv=xmas. The error consists on making diverge the boxlength of the system, the potential energy and pressure